### PR TITLE
Added check for newContent.contentBlocks.length

### DIFF
--- a/src/form-elements-edit.jsx
+++ b/src/form-elements-edit.jsx
@@ -70,7 +70,7 @@ export default class FormElementsEdit extends React.Component {
 
   convertFromHTML(content) {
     const newContent = convertFromHTML(content);
-    if (!newContent.contentBlocks) {
+    if (!newContent.contentBlocks || !newContent.contentBlocks.length) {
       // to prevent crash when no contents in editor
       return EditorState.createEmpty();
     }


### PR DESCRIPTION
- Bug:
When I added any form element and tried to change its label (Text to display), it works fine when I start removing "Placeholder Text..." or whatever text written in it, but when I delete the last letter i.e. when the textarea is empty, it crashes.

- Cause:
In form-elements-edit.jsx in the function convertFromHTML, when the textarea is empty the newContent.contentBlocks is not undefined, but it's an empty array, so it didn't go into the conditional statement and tried to createWithContent, which caused the crash.

- Fix: 
I added to the condition another condition: !newContent.contentBlocks.length, to cover the case of an empty array that's not 'undefined'.