### PR TITLE
using the `key` from user land is problematic here

### DIFF
--- a/src/toolbar.jsx
+++ b/src/toolbar.jsx
@@ -295,7 +295,7 @@ export default class Toolbar extends React.Component {
         <h4>Toolbox</h4>
         <ul>
           {
-            this.state.items.map((item) => (<ToolbarItem data={item} key={item.key} onClick={this._onClick.bind(this, item)} onCreate={this.create} />))
+            this.state.items.map((item, i) => (<ToolbarItem data={item} key={i} onClick={this._onClick.bind(this, item)} onCreate={this.create} />))
           }
         </ul>
       </div>


### PR DESCRIPTION
if someone uses more than one type of an input, react throws an error
about duplicate keys in a list.