### PR TITLE
Add canPopulateFromApi conditional

### DIFF
--- a/src/form-elements-edit.jsx
+++ b/src/form-elements-edit.jsx
@@ -344,7 +344,7 @@ export default class FormElementsEdit extends React.Component {
             <input id="correctAnswer" type="text" className="form-control" defaultValue={this.props.element.correct} onBlur={this.updateElement.bind(this)} onChange={this.editElementProp.bind(this, 'correct', 'value')} />
           </div>
         }
-        { this.props.element.hasOwnProperty('options') &&
+        { this.props.element.canPopulateFromApi && this.props.element.hasOwnProperty('options') &&
           <div className="form-group">
             <label className="control-label" htmlFor="optionsApiUrl">Populate Options from API</label>
             <div className="row">

--- a/src/toolbar.jsx
+++ b/src/toolbar.jsx
@@ -236,6 +236,8 @@ export default class Toolbar extends React.Component {
 
     if (item.canDefaultToday) { elementOptions.defaultToday = false; }
 
+    if (item.canPopulateFromApi) { elementOptions.canPopulateFromApi = true; }
+
     if (item.content) { elementOptions.content = item.content; }
 
     if (item.href) { elementOptions.href = item.href; }

--- a/src/toolbar.jsx
+++ b/src/toolbar.jsx
@@ -236,8 +236,6 @@ export default class Toolbar extends React.Component {
 
     if (item.canDefaultToday) { elementOptions.defaultToday = false; }
 
-    if (item.canPopulateFromApi) { elementOptions.canPopulateFromApi = true; }
-
     if (item.content) { elementOptions.content = item.content; }
 
     if (item.href) { elementOptions.href = item.href; }
@@ -247,6 +245,7 @@ export default class Toolbar extends React.Component {
     elementOptions.canHaveDisplayHorizontal = item.canHaveDisplayHorizontal !== false;
     elementOptions.canHaveOptionCorrect = item.canHaveOptionCorrect !== false;
     elementOptions.canHaveOptionValue = item.canHaveOptionValue !== false;
+    elementOptions.canPopulateFromApi = item.canPopulateFromApi !== false;
 
     if (item.key === 'Image') {
       elementOptions.src = item.src;


### PR DESCRIPTION
Makes the ability to populate option sets from an API endpoint optional via a prop. Defaults to `true` in order to make this an opt in decision, not breaking existing installs.