### PR TITLE
Fix Bug in saveFile method in FileUpload

### DIFF
--- a/src/form-elements/index.jsx
+++ b/src/form-elements/index.jsx
@@ -672,31 +672,30 @@ class FileUpload extends React.Component {
     });
   };
 
-  saveFile = (e) => {
+  saveFile = async (e) => {
     e.preventDefault();
     const sourceUrl = this.props.defaultValue;
-    fetch(sourceUrl, {
+    const response = await fetch(sourceUrl, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json; charset=utf-8',
-        OPTIONS: '',
       },
       responseType: 'blob',
-    }).then((response) => {
-      // eslint-disable-next-line no-undef
-      const blob = new Blob([response.data], {
-        type: this.props.data.fileType || response.headers.get('content-type'),
-      });
-      let fileName = response.headers.get('Content-Disposition');
-      if (fileName && fileName.indexOf(';filename=') > -1) {
-        [, fileName] = fileName.split(';filename=');
-        saveAs(blob, fileName);
-      } else {
-        fileName = sourceUrl.substring(sourceUrl.lastIndexOf('/') + 1);
-        saveAs(response.url, fileName);
-      }
     });
+    const dispositionHeader = response.headers.get('Content-Disposition');
+    const resBlob = await response.blob();
+    // eslint-disable-next-line no-undef
+    const blob = new Blob([resBlob], {
+      type: this.props.data.fileType || response.headers.get('Content-Type'),
+    });
+    if (dispositionHeader && dispositionHeader.indexOf(';filename=') > -1) {
+      const fileName = dispositionHeader.split(';filename=');
+      saveAs(blob, fileName);
+    } else {
+      const fileName = sourceUrl.substring(sourceUrl.lastIndexOf('/') + 1);
+      saveAs(response.url, fileName);
+    }
   };
 
   render() {


### PR DESCRIPTION
This PR fixes a bug in `saveFile` method of `FileUpload` component which was preventing the file to be downloaded properly.

PS: I found the following error in webpack config while compiling the new source code of rfb when running `npm start` after I updated to the latest version (after you implemented save form button to rfb). 
Error - 
```
× ｢wds｣: webpack Dev Server Invalid Options
options should NOT have additional properties
```
Screenshot - 
![Screenshot 2022-07-06 012242](https://user-images.githubusercontent.com/41051387/177405490-0de023a2-580d-4df4-805b-a696328d508f.jpg)

Please can you take a look into it.
