### PR TITLE
update typing for submitButton

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,6 +156,7 @@ export interface FormGeneratorProps {
   read_only?: boolean;
   // eslint-disable-next-line no-undef
   variables?: Record<any, any>;
+  submitButton?: JSX.Element;
 }
 
 export class ReactFormGenerator extends React.Component<FormGeneratorProps> {}


### PR DESCRIPTION
There is currently a missing type declaration for the `submitButton` prop in `ReactFormGenerator`