### PR TITLE
Parse the input value before format it in date picker

### DIFF
--- a/src/form-elements/date-picker.jsx
+++ b/src/form-elements/date-picker.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { format, parse } from 'date-fns';
+import { format, parse, parseISO } from 'date-fns';
 import ReactDatePicker from 'react-datepicker';
 import ComponentHeader from './component-header';
 import ComponentLabel from './component-label';
@@ -20,7 +20,7 @@ class DatePicker extends React.Component {
     const { formatMask } = this.state;
     if (dt && dt.target) {
       placeholder = (dt && dt.target && dt.target.value === '') ? formatMask.toLowerCase() : '';
-      const formattedDate = (dt.target.value) ? format(dt.target.value, formatMask) : '';
+      const formattedDate = (dt.target.value) ? format(parseISO(dt.target.value), formatMask) : '';
       this.setState({
         value: formattedDate,
         internalValue: formattedDate,


### PR DESCRIPTION
Or date-fns throws "Starting with v2.0.0-beta.1 date-fns doesn't accept strings as date arguments. Please use parseISO to parse strings. See: https://git.io/fjule" and the value does not update.