### PR TITLE
fix: Cannot have two HTML5 backends at the same time #304

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -52,7 +52,7 @@ class ReactFormBuilder extends React.Component {
     const currentAppLocale = AppLocale[language];
     if (this.props.toolbarItems) { toolbarProps.items = this.props.toolbarItems; }
     return (
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={HTML5Backend} context={window}>
         <IntlProvider
           locale={currentAppLocale.locale}
           messages={currentAppLocale.messages}>


### PR DESCRIPTION
This fixes [issue 304: Cannot have two HTML5 backends at the same time](https://github.com/Kiho/react-form-builder/issues/304).

I've tested this in my own nextjs app.  I had an earlier version (2yr ago) and never saw this issue.  Now it's painfully unavoidable.  I had even tried reverting to version 12 of `react-form-builder2` which worked in the past, but the problem isn't in `react-form-builder2` _per-se_, it's a combination of the nature of react-dnd, react/nextjs, and the way DNDProvider is called within `react-form-builder2`.

The problem arises that only one `react-dnd.DNDProvider` can be used in the app.  Once there are two, this error is thrown, unless they are given the same context to use, aka `window`.

Without digging into the reasons why, whenever you start dragging, you can see this error thrown multiple times (I saw 6 every time).

This fix sets the context to the window, eliminating the problem.

See this [issue on react-dnd](https://github.com/react-dnd/react-dnd/issues/3257) for more info, specifically [this "easy" fix](https://github.com/react-dnd/react-dnd/issues/3257#issuecomment-1809999397).