### PR TITLE
Don't clear the Signature field when the browser triggers a resize event

### DIFF
--- a/src/form-elements/index.jsx
+++ b/src/form-elements/index.jsx
@@ -335,6 +335,7 @@ class Signature extends React.Component {
       pad_props.ref = this.canvas;
       canClear = !this.props.read_only;
     }
+    pad_props.clearOnResize = false;
 
     let baseClasses = 'SortableItem rfb-item';
     if (this.props.data.pageBreakBefore) { baseClasses += ' alwaysbreak'; }


### PR DESCRIPTION
Fixes Kiho/react-form-builder#273