### PR TITLE
Fixing issue when dragging new item from toolbox

### DIFF
--- a/src/preview.jsx
+++ b/src/preview.jsx
@@ -220,7 +220,10 @@ export default class Preview extends React.Component {
   moveCard(dragIndex, hoverIndex) {
     const { data } = this.state;
     const dragCard = data[dragIndex];
-    this.saveData(dragCard, dragIndex, hoverIndex);
+    // happens sometimes when you click to insert a new item from the toolbox
+    if (dragCard !== undefined) {
+      this.saveData(dragCard, dragIndex, hoverIndex);
+    }
   }
 
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
If you drag a new item from the toolbox it can delete one of the existing questions in the form.